### PR TITLE
Position of ocm.rsp file in cli_latest_patch.rb recipe

### DIFF
--- a/recipes/cli_latest_patch.rb
+++ b/recipes/cli_latest_patch.rb
@@ -52,7 +52,7 @@ unless node[:oracle][:client][:latest_patch][:is_installed]
       command "curl -kO #{node[:oracle][:client][:response_file_url]}"
       user "oracli"
       group 'oracli'
-      cwd node[:oracle][:client][:install_dir]
+      cwd node[:oracle][:client][:ora_home]
     end
   else
     execute 'gen_response_file' do


### PR DESCRIPTION
To make sure ocm.rsp file is present, at line 55 in cli_latest_patch.rb recipe, there is a download in the  node[:oracle][:client][:install_dir]  folder, while the generation of a new one (line 62) is done in  node[:oracle][:client][:ora_home]  folder.
To make all this working, just make the previous folder equal to the second one ( node[:oracle][:client][:ora_home] ), which is the one used below.

Hope this helps, regards,
Giovanni