### PR TITLE
Found wrong paths for ocm.rsp in latest_dbpatch.rb

### DIFF
--- a/recipes/latest_dbpatch.rb
+++ b/recipes/latest_dbpatch.rb
@@ -57,7 +57,7 @@ unless node[:oracle][:rdbms][:latest_patch][:is_installed]
       command "curl #{node[:oracle][:curl_options]} #{node[:oracle][:rdbms][:response_file_url]}"
       user "oracle"
       group 'oinstall'
-      cwd node[:oracle][:rdbms][:install_dir]
+      cwd node[:oracle][:rdbms][:ora_home]
     end
   else
     execute 'gen_response_file' do


### PR DESCRIPTION
The path the ocm.rsp for the database server is inconsistent. It gets downloaded to "install_dir", but the patch installer expects it at "ora_home".

Can you please check and merge that and release it to the supermarket with all your other fixes please? 

Thx :+1: 