### PR TITLE
Handle the case when the oinstall group already exist on the network

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 default[:oracle][:user][:uid] = 201
 default[:oracle][:user][:gid] = 201
 default[:oracle][:user][:shell] = '/bin/ksh'
+default[:oracle][:user][:oinstall_group_exists] = false
 default[:oracle][:user][:sup_grps] = {'dba' => 202, 'bckpdba' => 203, 'dgdba' => 204, 'kmdba' => 205}
 default[:oracle][:user][:pw_set] = false
 default[:oracle][:user][:edb] = 'oracle'

--- a/recipes/oracle_user_config.rb
+++ b/recipes/oracle_user_config.rb
@@ -23,8 +23,10 @@
 # The argument to useradd's -g option must be an already existing
 # group, else useradd will raise an error.
 # Therefore, we must create the oinstall group before we do the oracle user.
-group 'oinstall' do
-  gid node[:oracle][:user][:gid]
+unless node[:oracle][:user][:oinstall_group_exists]
+  group 'oinstall' do
+    gid node[:oracle][:user][:gid]
+  end
 end
 
 user 'oracle' do


### PR DESCRIPTION
Hi Ari,

I ran into this problem while installing the oracle client on our machine as the group `oinstall` is already created on the network. With this change, we can avoid the error that chef will throw when trying to create an existing group.

The `oracli_user_config.rb` will also try to create as it is a default group in `node[:oracle][:cliuser][:sup_grps]` but this can be disabled by removing it from the default attributes or overriding it at the node/role level.

Let me know if you have any comments or questions
