### PR TITLE
Users can choose client type installation: Runtime, Administrator, ..., using two new attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,6 +54,8 @@ default[:oracle][:client][:is_installed] = false
 default[:oracle][:client][:install_info] = {}
 default[:oracle][:client][:install_dir] = "#{node[:oracle][:ora_base]}/install_dir_client"
 default[:oracle][:client][:response_file_url] = ''
+default[:oracle][:client][:installation_type] = 'Runtime'
+default[:oracle][:client][:custom_components] = ''
 
 # Dependencies for Oracle 11.2.
 # Source: <http://docs.oracle.com/cd/E11882_01/install.112/e24321/pre_install.htm#CIHFICFD>

--- a/metadata.json
+++ b/metadata.json
@@ -25,5 +25,5 @@
   },
   "recipes": {
   },
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'ari.riikonen@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures Oracle rdbms and client on CentOS 6.5'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.3'
+version          '1.2.4'
 supports         'redhat'
 supports         'centos'

--- a/recipes/clibin.rb
+++ b/recipes/clibin.rb
@@ -84,6 +84,9 @@ end
 
 # Filesystem template.
 template "#{node[:oracle][:client][:install_dir]}/cli11R23.rsp" do
+  variables(
+      :installation_type => "#{node[:oracle][:client][:installation_type]}",
+      :custom_components => "#{node[:oracle][:client][:custom_components]}" )
   owner 'oracli'
   group 'oracli'
   mode '0644'

--- a/templates/default/cli11R23.rsp.erb
+++ b/templates/default/cli11R23.rsp.erb
@@ -5,8 +5,8 @@ INVENTORY_LOCATION=/opt/oraInventory
 SELECTED_LANGUAGES=en
 ORACLE_HOME=<%= node[:oracle][:client][:ora_home] %>
 ORACLE_BASE=<%= node[:oracle][:ora_base] %>
-oracle.install.client.installType=Runtime
-oracle.install.client.customComponents=
+oracle.install.client.installType=<%= @installation_type %>
+oracle.install.client.customComponents=<%= @custom_components %>
 oracle.install.client.oramtsPortNumber=
 oracle.install.client.schedulerAgentHostName=
 oracle.install.client.schedulerAgentPortNumber=


### PR DESCRIPTION
	modified:   attributes/default.rb
	modified:   metadata.json
	modified:   metadata.rb
	modified:   recipes/clibin.rb
	modified:   templates/default/cli11R23.rsp.erb